### PR TITLE
Sep workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: build and deploy docs
 on:
   pull_request:
     branches: [ main ]
-
+jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions: write-all

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: build and deploy docs
+
+on:
+  pull_request:
+    branches: [ main ]
+
+  deploy:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.5.3
+
+      - name: Build
+        uses: andstor/jsdoc-action@v1
+        with:
+          source_dir: ./src
+          output_dir: ./out
+          recurse: true
+          front_page: README.md
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          publish_dir: ./out

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: test and lint code
 
 on:
   push:
@@ -22,27 +22,7 @@ jobs:
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run test
-      
-  deploy:
-    runs-on: ubuntu-latest
-    permissions: write-all
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3.5.3
 
-      - name: Build
-        uses: andstor/jsdoc-action@v1
-        with:
-          source_dir: ./src
-          output_dir: ./out
-          recurse: true
-          front_page: README.md
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          publish_dir: ./out
   lint:
     runs-on: ubuntu-latest
     permissions: write-all


### PR DESCRIPTION
Separate the building/testing workflow and the docbuild workflow so that the docbuild only runs on PR. This way the doc build is not run repeatedly and docs are only built before merging