### PR TITLE
Doc previews on pull request, build on merge

### DIFF
--- a/.github/workflows/preview_doc.yml
+++ b/.github/workflows/preview_doc.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Deploy Preview
         uses: rossjrw/pr-preview-action@v1
         with:
-          publish_dir: ./out/
+          source_dir: ./out/

--- a/.github/workflows/preview_doc.yml
+++ b/.github/workflows/preview_doc.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Deploy Preview
         uses: rossjrw/pr-preview-action@v1
         with:
-          source_dir: ./out/
+          source_dir: ./out

--- a/.github/workflows/preview_doc.yml
+++ b/.github/workflows/preview_doc.yml
@@ -1,7 +1,7 @@
-name: build and deploy docs
+name: Preview PR Docs
 
 on:
-  push:
+  pull-request:
     branches:
       - main
 jobs:
@@ -20,8 +20,7 @@ jobs:
           recurse: true
           front_page: README.md
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Deploy Preview
+        uses: rossjrw/pr-preview-action@v1
         with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./out

--- a/.github/workflows/preview_doc.yml
+++ b/.github/workflows/preview_doc.yml
@@ -1,7 +1,7 @@
 name: Preview PR Docs
 
 on:
-  pull-request:
+  pull_request:
     branches:
       - main
 jobs:

--- a/.github/workflows/preview_doc.yml
+++ b/.github/workflows/preview_doc.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Deploy Preview
         uses: rossjrw/pr-preview-action@v1
         with:
-          source_dir: ./out
+          source-dir: ./out

--- a/.github/workflows/preview_doc.yml
+++ b/.github/workflows/preview_doc.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Deploy Preview
         uses: rossjrw/pr-preview-action@v1
         with:
-          publish_dir: ./out
+          publish_dir: ./out/


### PR DESCRIPTION
## Preview docs on pull request

# Description:
This sets up the workflows such that doc previews which do not change the main doc pages are deployed on the creation of a pull request for review, and when the PR is actually merged, we deploy to the main docs pages.

# Content
- Adds a new workflow for creating doc previews
- Edits the pages deployment workflow to be triggered only on pushes to the main branch

# Related issues
- #18 

# Todo
- [x] Verify that the preview workflow is working by viewing the preview created by this PR
